### PR TITLE
Swap s3 cache component paths

### DIFF
--- a/src/python/verst/pants/s3cache/s3cache.py
+++ b/src/python/verst/pants/s3cache/s3cache.py
@@ -164,4 +164,7 @@ class S3ArtifactCache(ArtifactCache):
     return s3.Object(self._bucket, self._path_for_key(cache_key))
 
   def _path_for_key(self, cache_key):
-    return '{0}/{1}/{2}.tgz'.format(self._path, cache_key.id, cache_key.hash)
+    if len(self._path) == 0:
+      return '{1}/{2}.tgz'.format(cache_key.hash, cache_key.id)
+    else:
+      return '{0}/{1}/{2}.tgz'.format(self._path, cache_key.hash, cache_key.id)

--- a/src/python/verst/pants/s3cache/s3cache.py
+++ b/src/python/verst/pants/s3cache/s3cache.py
@@ -165,6 +165,6 @@ class S3ArtifactCache(ArtifactCache):
 
   def _path_for_key(self, cache_key):
     if len(self._path) == 0:
-      return '{1}/{2}.tgz'.format(cache_key.hash, cache_key.id)
+      return '{0}/{1}.tgz'.format(cache_key.hash, cache_key.id)
     else:
       return '{0}/{1}/{2}.tgz'.format(self._path, cache_key.hash, cache_key.id)


### PR DESCRIPTION
@toddgardner @JoeEnnever   Two minor fixes here related to getting more randomness in the s3 key prefix, which results in better performance:

1. Allowing `self._path` to be empty. This means you can use an s3_url like `s3://mybucket` without any sub folder.
2. Switching the cache components in the path, because the hash is more unique than the object name/id. I didn't look deeply, but I dont see any code that assumes the structure (i.e. does a listing of `s3://mybucket/com.foo.bar/*`).