### PR TITLE
Tweak README instructions for latest Pants

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Change your pants.ini
 
 ```
 [GLOBAL]
+plugin_version: 1.2.0
+
 plugins: +[
-    "verst.pants.docker==1.2.0",
+    "verst.pants.docker==%(plugin_version)s",
   ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current Plugins:
 * verst.pants.docker - docker integration for pants.
 * verst.pants.ensime - An updated ensime generator, installed under ensime-verst
 * verst.pants.k8s - Tools for controlling k8s from pants (currently can clone namespaces)
-* verst.pants.resources - Adds an absolute_resources target, which places references with 
+* verst.pants.resources - Adds an absolute_resources target, which places references with
 * verst.pants.scalastyle - adds scalastyle to compile, with a soft failure mode
 * verst.pants.slick - adds a slick_gen rule for generating slick from the repo.
 * verst.pants.specs2 - add a specs2_tests rule for running specs2 files directly.
@@ -35,15 +35,8 @@ Change your pants.ini
 
 ```
 [GLOBAL]
-plugin_version: 1.1.1
-
 plugins: +[
-    "verst.pants.docker==%(plugin_version)s",
-  ]
-
-# Install the packages
-backend_packages: +[
-    "verst.pants.docker",
+    "verst.pants.docker==1.2.0",
   ]
 ```
 


### PR DESCRIPTION
I tried using this plugin with Pants 1.6.0 today and the instructions in the README did not work for me.

I was getting this error out of `docker/register.py`:

```
Exception message: Can only specify a task name once per goal, saw multiple values for docker-jvm in goal bundle
```

I'm somewhat new to working with Pants, but it looks to me like having the plugin represented in both `backend_packages` and `plugins` was causing it to load twice. The plugin worked fine once I removed the `backend_packages` section.

