### PR TITLE
Update for py3 pants build system

### DIFF
--- a/src/python/verst/pants/docker/docker_python_bundle_task.py
+++ b/src/python/verst/pants/docker/docker_python_bundle_task.py
@@ -45,7 +45,7 @@ class DockerPythonBundleTask(DockerBaseBundleTask):
 
   def _prepare_directory(self, target, dependency, tmpdir):
     archive_mapping = self.context.products.get('pex_archives').get(dependency)
-    basedir, paths = archive_mapping.items()[0]
+    basedir, paths = list(archive_mapping.items())[0]
     path = paths[0]
     archive_path = os.path.join(basedir, path)
 


### PR DESCRIPTION
Pants is moving to python3 and dropping py2

The above change fixes the error below:
Exception message: 'dict_items' object does not support indexing